### PR TITLE
Remove `build` from package dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-  'build >= 1.0.3',
   'requests >= 2.28',
   'pydantic >= 1.9',
   'chroma-hnswlib==0.7.3',


### PR DESCRIPTION
## Description of changes

`build` was added in https://github.com/chroma-core/chroma/pull/1561 to fix the build of the client. This is a build-time dependency and should not be needed at runtime. Thus it should suffice to be in `requirements-dev.txt`.

## Test plan
*How are these changes tested?*

- [ ] Tests should pass in CI to ensure that the place in the CI pipeline that required the dependency on build correctly gets it via `requirement_dev.txt` and not via the package runtime dependencies.

## Documentation Changes
*Are all docstrings for user-facing APIs updated if required? Do we need to make documentation changes in the [docs repository](https://github.com/chroma-core/docs)?*

No changes in docs.
